### PR TITLE
target: Clean variables and fix IP package generation

### DIFF
--- a/axirt.mk
+++ b/axirt.mk
@@ -19,7 +19,6 @@ REGTOOL    ?= $(shell $(BENDER) path register_interface)/vendor/lowrisc_opentita
 AXIRT_NUM_MGRS ?= 8
 AXIRT_NUM_SUBS ?= 2
 
-AXIRTROOT    ?= $(shell $(BENDER) path axi_rt)
 AXIRTXILROOT  = $(AXIRTROOT)/target/xilinx
 
 # Reconfigure Registers

--- a/target/xilinx/README.md
+++ b/target/xilinx/README.md
@@ -59,4 +59,6 @@ not provided.
 
 To add AXI RT IP to a block design, source `scripts/add_axirt_ip.tcl` during the
 block design creation flow. This will add the folder `target/xilinx/axirt_ip` in
-the Xilinx IP catalog, and will instantiate AXI RT in the block design.
+the Xilinx IP catalog, and will instantiate AXI RT in the block design. For the
+command to work, set the correct absolute location of the AXI RT packaged IP
+folder using the variable `AXIRTIP_DIR`, used in `scripts/add_axirt_ip.tcl`.

--- a/target/xilinx/scripts/add_axirt_ip.tcl
+++ b/target/xilinx/scripts/add_axirt_ip.tcl
@@ -8,9 +8,7 @@
 # Add packaged AXI RT IP to Vivado IP catalog and instantiate it in a block
 # design. This script is meant to be used during a block design.
 
-set project $::env(XILINX_PROJECT)
-
-set_property ip_repo_paths $project [current_project]
+set_property ip_repo_paths $AXIRTIP_DIR [current_project]
 update_ip_catalog
 
 create_bd_cell -type ip -vlnv ethz.ch:user:axi_rt_unit_top_xilinx_ip:1.0 axirt_ip_0

--- a/target/xilinx/scripts/run.tcl
+++ b/target/xilinx/scripts/run.tcl
@@ -10,11 +10,10 @@
 # Change XILINX_PART according to the target board
 
 # Create project
-set project $::env(XILINX_PROJECT)
+set ip_root_dir $::env(XILINX_PROJECT)
 set part $::env(XILINX_PART)
-set ip_root_dir $project
 
-create_project $project . -force -part $part
+create_project $ip_root_dir . -force -part $part
 set_property XPM_LIBRARIES XPM_MEMORY [current_project]
 
 # set number of threads to 8 (maximum, unfortunately)
@@ -320,6 +319,8 @@ ipx::check_integrity [ipx::current_core]
 #WARNING: [IP_Flow 19-7070] Found addressable master interface 'm_axi_rt' without an associated address space. An addressable master interface must reference a valid address space within this IP for addressing to succeed. Please repackage this interface to provide the required address space information.
 #WARNING: [IP_Flow 19-7071] Found addressable slave interface 's_axi_rt' without an associated memory map. An addressable slave interface must reference a valid memory map within this IP for addressing to succeed. Please repackage this interface to provide the required memory map information.
 ipx::save_core [ipx::current_core]
-create_ip -verbose -module_name $project -vlnv ethz.ch:user:axi_rt_unit_top_xilinx_ip
+set_property ip_repo_paths $ip_root_dir [current_project]
+update_ip_catalog
+create_ip -verbose -module_name $ip_root_dir -vlnv ethz.ch:user:axi_rt_unit_top_xilinx_ip
 
 exit

--- a/target/xilinx/xilinx.mk
+++ b/target/xilinx/xilinx.mk
@@ -36,14 +36,12 @@ $(AXIRTXILROOT)/scripts/compile.axirt.xilinx.tcl:
 	$(BENDER) script vivado -t rtl -t fpga > $@
 
 # Package IP
-$(AXIRTXILROOT)/$(AXIRTXILPROJ).xci: $(AXIRTXILROOT)/$(AXIRTXILPROJ).xpr
-
 $(AXIRTXILROOT)/$(AXIRTXILPROJ).xpr:
 	cd $(AXIRTXILROOT) && $(VIVADO_ENV) $(VIVADO) -mode $(VIVADO_MODE) -source $(AXIRTROOT)/scripts/run.tcl
 
 .PHONY: axirt-xil-all axirt-xil-clean
 
-axirt-xil-all: $(AXIRTXILROOT)/scripts/compile.axirt.xilinx.tcl $(AXIRTXILROOT)/$(AXIRTXILPROJ).xci
+axirt-xil-all: $(AXIRTXILROOT)/scripts/compile.axirt.xilinx.tcl $(AXIRTXILROOT)/$(AXIRTXILPROJ).xpr
 
 axirt-xil-clean:
 	rm -rf $(AXIRTXILROOT)/.Xil


### PR DESCRIPTION
* We need to set the `ip_repo_paths` to succesfully create the IP. This got lost in translation when the flow was added.