### PR TITLE
Fix axi_write_buffer

### DIFF
--- a/src/axi_write_buffer.sv
+++ b/src/axi_write_buffer.sv
@@ -154,14 +154,12 @@ module axi_write_buffer #(
     // default
     num_lasts_d = num_lasts_q;
 
-    // if one enters the queue: increment counter
-    if (ingress_w_last) begin
-      num_lasts_d = num_lasts_d + 1;
-    end
-
-    // if one leaves: decrease counter
-    if (egress_w_last & mgmt_ready_aw) begin
-      num_lasts_d = num_lasts_d - 1;
+    // one enters and none leaves: increase counter
+    if (ingress_w_last & !egress_w_last) begin
+      num_lasts_d = num_lasts_q + 1;
+    // one leaves and none enter: decrease counter
+    end else if (egress_w_last & !ingress_w_last) begin
+      num_lasts_d = num_lasts_q - 1;
     end
   end
 


### PR DESCRIPTION
- I assume the _d to _d assignment is a typo

- If there is an ingress and an egress at the same time, the counter will count down 1 instead of staying the same

- For ` if (egress_w_last & mgmt_ready_aw)`, in the case of a multi-beat write, wouldn't the AW handshake long be finished when the last W beat leaves the buffer? We saw the num_lasts counter not being decremented and overflowing when preloading from the debug module using progbuf, which caused a deadlock (monitored on the FPGA with ILAs).
This was tested by using the `axirt_budget` test from Cheshire as a means of configuration and then trying to preload anything using GDB.