### PR TITLE
Don't force `PYTHON` variable in `xilinx.mk` makefrag

### DIFF
--- a/target/xilinx/xilinx.mk
+++ b/target/xilinx/xilinx.mk
@@ -6,7 +6,7 @@
 # - Alessandro Ottaviano <aottaviano@ethz.ch>
 
 AXIRTXILROOT ?= .
-PYTHON       := python3
+PYTHON       ?= python3
 
 # Vivado options
 VIVADO       ?= vitis-2022.1 vivado


### PR DESCRIPTION
The `xilinx.mk` file is a nested include make fragment in cheshire, and systems that include `cheshire.mk`, will have their `PYTHON` variable overridden.